### PR TITLE
Note that folks have to enter their API key before the example app will work

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -38,7 +38,7 @@
 - Xcode 11.3 and later  
 
 ### Github Example Repo 
-- Run the example app to see the GIPHY SDK in action with all of its configurations. Run `pod install` before building the example app. 
+- Run the example app to see the GIPHY SDK in action with all of its configurations. Run `pod install` and set your API key [here](https://github.com/Giphy/giphy-ios-sdk-ui-example/blob/master/Swift/Example/ViewController.swift#L113) before building the example app. 
 - Open [issues or feature requests](https://github.com/Giphy/giphy-ios-sdk-ui-example/issues)  
 - View [releases](https://github.com/Giphy/giphy-ios-sdk-ui-example/releases)
 


### PR DESCRIPTION
Before I entered my API key there, the Giphy controller would present but then show a loading indicator forever.

Some ways to make this even nicer:

* seems like the user should see some sort of error in the console or even in the Giphy controller itself if the SDK isn't configured with a key?
* maybe you folks could make the example app work without a key 🙊? Would be super slick to make it turn-key.