### PR TITLE
Updating language around API keys

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -77,9 +77,9 @@ import GiphyUISDK
 import GiphyCoreSDK
 ```
 
-Configure your API key. Apply for an API key [here](https://developers.giphy.com/dashboard/).
+Configure your API key. Apply for a new __iOS SDK__ key [here](https://developers.giphy.com/dashboard/). Please remember, you should use a separate key for every platform (Android, iOS, Web) you add our SDKs to.
 ```swift
-Giphy.configure(apiKey: "yOuR_kEy_HeRe")
+Giphy.configure(apiKey: "yOuR_iOs_SdK_kEy_HeRe")
 ```
 
 ## Custom UI


### PR DESCRIPTION
JIRA reference: https://giphypedia.atlassian.net/browse/IN-67
Product Brief: https://giphypedia.atlassian.net/wiki/spaces/DEV/pages/1726087342/Developer+Lifecycle+Improvements

In an attempt to highlight that developers should create **separate** **SDK** keys for every platform, i wanted to make this change to the documentation. 

@cgmaier would love your feedback on whether this is effective wording? 

